### PR TITLE
Provided compatibility with stylelint 16 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,15 @@
   "repository": "csstools/stylelint-use-nesting",
   "homepage": "https://github.com/csstools/stylelint-use-nesting#readme",
   "bugs": "https://github.com/csstools/stylelint-use-nesting/issues",
-  "main": "index.cjs",
+  "main": "index.mjs",
+  "type": "module",
   "module": "index.mjs",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "node": "./index.cjs"
+      "import": "./index.mjs"
     }
   },
   "files": [
-    "index.cjs",
-    "index.cjs.map",
     "index.mjs",
     "index.mjs.map"
   ],
@@ -38,7 +36,7 @@
     "eslint-config-dev": "3.1.0",
     "pre-commit": "1.2.2",
     "rollup": "3.18.0",
-    "stylelint": "15.2.0",
+    "stylelint": "^16.0.1",
     "stylelint-tape": "3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
With the release of Stylelint 16.0.0, the CommonJS Node.js API has been deprecated, which could lead to implementation challenges for users of the stylelint-use-nesting plugin. While the plugin currently offers .mjs files, this setup requires users to adopt the stylelint.config.mjs configuration file and ensure that their entire project is compatible with ES modules. This requirement may not be trivial for all users and could limit the plugin's usability.

To enhance compatibility and future-proof the plugin, I propose the following changes:

Remove CommonJS support: By focusing solely on ESM (ECMAScript Modules), we align with the current direction of JavaScript development and tooling. This change simplifies the plugin's structure and reduces potential confusion about which module system to use.
Upgrade the minimum version requirement for Stylelint: By specifying Stylelint ^16.0.1 as the minimum version in peerDependencies, we ensure that users of the plugin are on a version that supports ESM. This move also helps prevent issues that may arise from the deprecated CommonJS API.
These changes aim to streamline the user experience, reduce potential implementation hurdles, and ensure that the stylelint-use-nesting plugin remains a valuable tool for developers seeking to enforce nesting in CSS with the latest versions of Stylelint.