### PR TITLE
Fix false positive with `:host` and `:host()`

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -47,6 +47,11 @@ export default {
 			expect: '.foo { color: blue; &:hover, &:focus { color: rebeccapurple; } } .foo:focus-within { color: red; }',
 			args: ['always', { only: [':hover', ':focus'] }]
 		},
+		{
+			source: ':host { color: blue; } :host(.foo) { color: rebeccapurple; }',
+			expect: ':host { color: blue; } :host(.foo) { color: rebeccapurple; }',
+			args: ['always']
+		},
 
 		/* Test Nesting At-Rules */
 		{

--- a/lib/are-rules-potential-nesting-rule.mjs
+++ b/lib/are-rules-potential-nesting-rule.mjs
@@ -8,6 +8,7 @@ export default function areRulesPotentialNestingRule(rule1, rule2, opts) {
 				rule2Selector.length < rule1Selector.length &&
 				rule2Selector === rule1Selector.slice(0, rule2Selector.length) &&
 				!/^[A-Za-z0-9-_]/.test(rule1Selector.slice(rule2Selector.length)) &&
+				rule1Selector[rule2Selector.length] !== '(' &&
 				(!except.length || except.some(
 					entry => entry instanceof RegExp
 						? !entry.test(rule1Selector.slice(rule2Selector.length))


### PR DESCRIPTION
Fixes #23.

This fix would also cover any future cases when there's a pseudo-class with a same-named pseudo-class function.